### PR TITLE
Update  IE Crusher atm_star_shard.json

### DIFF
--- a/src/main/resources/data/immersiveengineering/recipe/atmstarshard/atm_star_shard.json
+++ b/src/main/resources/data/immersiveengineering/recipe/atmstarshard/atm_star_shard.json
@@ -1,9 +1,9 @@
 {
   "type": "immersiveengineering:crusher",
-  "secondaries": [
-  ],
   "result": {
-    "item": "allthetweaks:atm_star_shard",
+    "basePredicate": {
+      "item": "allthetweaks:atm_star_shard",
+    },
     "count": 5
   },
   "input": {
@@ -12,7 +12,7 @@
   "energy": 3200,
   "conditions": [
     {
-      "type": "forge:mod_loaded",
+      "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
     }
   ]


### PR DESCRIPTION
Updated the IE crusher json for the atm star shard to match the neoforge and 1.21.1 IE changes.