### PR TITLE
Fix macOS LinkageError from shaded Jna-platform conflicting with Minecraft

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,8 @@ dependencies {
     shadow("com.github.CrashSystemZ:jDRPC:v1.2.1") {
         transitive = false
     }
-    shadow("net.java.dev.jna:jna-platform:5.17.0")
+    // JNA is provided by Minecraft 26.1+ (MacosUtil / ca.weblite.objc). Bundling it here
+    // causes LinkageError on macOS from duplicate com.sun.jna.Pointer class loaders.
     implementation "curse.maven:better-compatibility-checker-551894:7905240"
     implementation "curse.maven:applied-energistics-2-223794:7368867"
     implementation "curse.maven:pipez-443900:7904268"


### PR DESCRIPTION
## Summary

Fixes #43.

On macOS (Apple Silicon, MC 26.1.2+), the client could crash shortly after launch with a `java.lang.LinkageError` when fullscreen/window mode was updated. Two class loaders were loading different copies of `com.sun.jna.Pointer` — one from the mod's shadow JAR and one from Minecraft's runtime libraries used by `MacosUtil` / `ca.weblite.objc`.

This removes `jna-platform` from the shadow configuration. Minecraft 26.1+ already ships `jna` and `jna-platform` 5.17.0 on all platforms, so jDRPC (Discord RPC) can use the game's copy at runtime.

## Changes

- Stop shading `net.java.dev.jna:jna-platform:5.17.0` into the mod JAR
- Add a comment in `build.gradle` explaining why JNA must not be bundled

## Impact

| Platform | Discord RPC | Risk |
|----------|-------------|------|
| macOS | Uses `UnixConnection` (no JNA) | Fixes the crash |
| Linux | Uses `UnixConnection` (no JNA) | No change |
| Windows | Uses `WindowsConnection` (JNA) | Uses Minecraft's bundled JNA |

JAR size drops from ~3.6 MB to ~375 KB.

